### PR TITLE
Add hotkey manager MVP implementation

### DIFF
--- a/stream_animate/__init__.py
+++ b/stream_animate/__init__.py
@@ -1,0 +1,3 @@
+"""Streaming Companion Tool core package."""
+
+__all__ = ["hotkeys"]

--- a/stream_animate/hotkeys.py
+++ b/stream_animate/hotkeys.py
@@ -1,0 +1,143 @@
+"""Hotkey management utilities for the Streaming Companion Tool."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Optional
+
+from pynput import keyboard
+
+Callback = Callable[[], None]
+
+
+@dataclass
+class _Binding:
+    combination: str
+    callback: Callback
+    hotkey: keyboard.HotKey
+
+
+class HotkeyManager:
+    """Manage registration and dispatch of global hotkeys."""
+
+    def __init__(
+        self,
+        listener_factory: Optional[Callable[[Callable, Callable], keyboard.Listener]] = None,
+        hotkey_factory: Optional[Callable[[str, Callback], keyboard.HotKey]] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._listener_factory = listener_factory or self._default_listener_factory
+        self._hotkey_factory = hotkey_factory or self._default_hotkey_factory
+        self._logger = logger or logging.getLogger(__name__)
+        self._listener: Optional[keyboard.Listener] = None
+        self._hotkeys: Dict[str, _Binding] = {}
+
+    @staticmethod
+    def _default_listener_factory(
+        on_press: Callable[[keyboard.Key | keyboard.KeyCode], None],
+        on_release: Callable[[keyboard.Key | keyboard.KeyCode], None],
+    ) -> keyboard.Listener:
+        return keyboard.Listener(on_press=on_press, on_release=on_release)
+
+    @staticmethod
+    def _default_hotkey_factory(combination: str, on_activate: Callback) -> keyboard.HotKey:
+        parsed = keyboard.HotKey.parse(combination)
+        return keyboard.HotKey(parsed, on_activate)
+
+    @staticmethod
+    def _normalize_combination(combination: str) -> str:
+        parts = [segment.strip() for segment in combination.split("+")]
+        return "+".join(parts).lower()
+
+    @property
+    def is_running(self) -> bool:
+        with self._lock:
+            listener = self._listener
+        return bool(listener and listener.running)
+
+    def start(self) -> bool:
+        with self._lock:
+            if self._listener is not None:
+                return False
+            listener = self._listener_factory(self._on_press, self._on_release)
+            self._listener = listener
+        listener.start()
+        self._logger.info("Hotkey manager started with %d hotkeys", len(self._hotkeys))
+        return True
+
+    def stop(self) -> bool:
+        with self._lock:
+            listener = self._listener
+            if listener is None:
+                return False
+            self._listener = None
+        listener.stop()
+        self._logger.info("Hotkey manager stopped")
+        return True
+
+    def register_hotkey(self, combination: str, callback: Callback) -> None:
+        if not combination:
+            raise ValueError("Hotkey combination must be a non-empty string")
+        if not callable(callback):
+            raise ValueError("Hotkey callback must be callable")
+
+        normalized = self._normalize_combination(combination)
+        with self._lock:
+            if normalized in self._hotkeys:
+                raise ValueError(f"Hotkey '{combination}' already registered")
+            hotkey = self._hotkey_factory(
+                combination,
+                lambda combo=normalized: self._execute_callback(combo),
+            )
+            self._hotkeys[normalized] = _Binding(combination, callback, hotkey)
+        self._logger.info("Registered hotkey %s", combination)
+
+    def unregister_hotkey(self, combination: str) -> bool:
+        normalized = self._normalize_combination(combination)
+        with self._lock:
+            removed = self._hotkeys.pop(normalized, None)
+        if removed:
+            self._logger.info("Unregistered hotkey %s", combination)
+            return True
+        self._logger.debug("Attempted to remove unknown hotkey %s", combination)
+        return False
+
+    def trigger(self, combination: str) -> bool:
+        normalized = self._normalize_combination(combination)
+        return self._execute_callback(normalized)
+
+    def registered_combinations(self) -> Iterable[str]:
+        with self._lock:
+            return tuple(binding.combination for binding in self._hotkeys.values())
+
+    def _execute_callback(self, normalized: str) -> bool:
+        with self._lock:
+            binding = self._hotkeys.get(normalized)
+        if not binding:
+            self._logger.debug("Hotkey %s not found", normalized)
+            return False
+        try:
+            binding.callback()
+        except Exception:  # pragma: no cover - defensive logging
+            self._logger.exception("Hotkey callback for %s raised an exception", binding.combination)
+            return False
+        return True
+
+    def _on_press(self, key: keyboard.Key | keyboard.KeyCode) -> None:  # pragma: no cover - integration path
+        self._dispatch("press", key)
+
+    def _on_release(self, key: keyboard.Key | keyboard.KeyCode) -> None:  # pragma: no cover - integration path
+        self._dispatch("release", key)
+
+    def _dispatch(self, action: str, key: keyboard.Key | keyboard.KeyCode) -> None:
+        with self._lock:
+            listener = self._listener
+            hotkeys = list(self._hotkeys.values())
+        if listener is None:
+            return
+        canonical_key = listener.canonical(key)
+        for binding in hotkeys:
+            getattr(binding.hotkey, action)(canonical_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_hotkeys.py
+++ b/tests/test_hotkeys.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+from typing import Callable, List
+
+import pytest
+
+from stream_animate.hotkeys import HotkeyManager
+
+
+class FakeListener:
+    def __init__(self, on_press: Callable, on_release: Callable) -> None:
+        self.on_press = on_press
+        self.on_release = on_release
+        self.running = False
+        self._canonical_calls: List = []
+
+    def start(self) -> None:
+        self.running = True
+
+    def stop(self) -> None:
+        self.running = False
+
+    def canonical(self, key):
+        self._canonical_calls.append(key)
+        return key
+
+
+class FakeHotKey:
+    def __init__(self, combination: str, callback: Callable[[], None]) -> None:
+        self.combination = combination
+        self.callback = callback
+        self.press_calls: List = []
+        self.release_calls: List = []
+
+    def press(self, key) -> None:
+        self.press_calls.append(key)
+
+    def release(self, key) -> None:
+        self.release_calls.append(key)
+        self.callback()
+
+
+def make_manager():
+    listener_ref = {}
+
+    def listener_factory(on_press, on_release):
+        listener = FakeListener(on_press, on_release)
+        listener_ref["instance"] = listener
+        return listener
+
+    def hotkey_factory(combination, callback):
+        hotkey = FakeHotKey(combination, callback)
+        return hotkey
+
+    manager = HotkeyManager(
+        listener_factory=listener_factory,
+        hotkey_factory=hotkey_factory,
+        logger=logging.getLogger("test.hotkeys"),
+    )
+    return manager, listener_ref
+
+
+def test_register_and_trigger_executes_callback():
+    manager, _ = make_manager()
+    calls: List[str] = []
+
+    manager.register_hotkey("<ctrl>+<alt>+c", lambda: calls.append("hit"))
+    assert manager.trigger("<CTRL> + <ALT> + C") is True
+    assert calls == ["hit"]
+    assert "<ctrl>+<alt>+c" in manager.registered_combinations()
+
+
+def test_duplicate_registration_raises_value_error():
+    manager, _ = make_manager()
+    manager.register_hotkey("a", lambda: None)
+    with pytest.raises(ValueError):
+        manager.register_hotkey("A", lambda: None)
+
+
+def test_unregister_hotkey_removes_binding():
+    manager, _ = make_manager()
+    manager.register_hotkey("a", lambda: None)
+    assert manager.unregister_hotkey("a") is True
+    assert manager.unregister_hotkey("a") is False
+    assert manager.trigger("a") is False
+
+
+def test_start_and_stop_control_listener_state():
+    manager, listener_ref = make_manager()
+
+    assert manager.start() is True
+    assert manager.is_running is True
+    assert manager.start() is False
+
+    listener = listener_ref["instance"]
+    assert listener.running is True
+
+    assert manager.stop() is True
+    assert listener.running is False
+    assert manager.stop() is False
+
+
+def test_dispatch_invokes_hotkey_press_and_release():
+    manager, listener_ref = make_manager()
+    events: List[str] = []
+
+    manager.register_hotkey("b", lambda: events.append("released"))
+    manager.start()
+    listener = listener_ref["instance"]
+    fake_key = object()
+
+    listener.on_press(fake_key)
+    listener.on_release(fake_key)
+
+    binding = next(iter(manager._hotkeys.values()))  # type: ignore[attr-defined]
+    assert binding.hotkey.press_calls == [fake_key]
+    assert binding.hotkey.release_calls == [fake_key]
+    assert events == ["released"]
+    manager.stop()


### PR DESCRIPTION
## Summary
- add `HotkeyManager` capable of registering, triggering, and removing global shortcuts
- provide abstraction hooks for listener/hotkey factories and structured logging
- add unit tests with fakes to cover registration, lifecycle, and dispatch behaviour

## Testing
- `python run_checks.py`

Fixes #1