### PR TITLE
Add sound playback service

### DIFF
--- a/src/stream_companion/__init__.py
+++ b/src/stream_companion/__init__.py
@@ -1,3 +1,3 @@
 """Streaming Companion Tool core package."""
 
-__all__ = ["hotkeys"]
+__all__ = ["hotkeys", "sound"]

--- a/src/stream_companion/sound.py
+++ b/src/stream_companion/sound.py
@@ -1,4 +1,8 @@
-"""Sound playback utilities for the Streaming Companion Tool."""
+"""Sound playback utilities for the Streaming Companion Tool.
+
+This module provides the `SoundPlayer` class for loading and playing audio
+effects with `pygame.mixer`.
+"""
 
 from __future__ import annotations
 
@@ -78,16 +82,20 @@ class SoundPlayer:
             raise ValueError("sound_id must be provided")
 
         path = Path(file_path)
-        if not path.is_file():
-            self._logger.warning("Sound file missing: %s", path)
+        if not path.exists() or not path.is_file():
+            self._logger.warning("Sound file missing or not a file: %s", path)
             return False
 
         self._ensure_initialized()
 
         try:
             sound = self._mixer.Sound(path.as_posix())
-        except Exception:  # pragma: no cover - defensive logging
-            self._logger.exception("Failed to load sound: %s", path)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.exception(
+                "Failed to load sound: %s (%s)",
+                path,
+                type(exc).__name__,
+            )
             return False
 
         self._sounds[sound_id] = sound
@@ -113,8 +121,12 @@ class SoundPlayer:
             return False
         try:
             sound.play(loops=loops)
-        except Exception:  # pragma: no cover - defensive logging
-            self._logger.exception("Failed to play sound '%s'", sound_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.exception(
+                "Failed to play sound '%s' (%s)",
+                sound_id,
+                type(exc).__name__,
+            )
             return False
         return True
 

--- a/src/stream_companion/sound.py
+++ b/src/stream_companion/sound.py
@@ -1,0 +1,135 @@
+"""Sound playback utilities for the Streaming Companion Tool."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+import pygame.mixer
+
+Logger = logging.Logger
+
+
+class SoundPlayer:
+    """Load and play short audio clips using ``pygame.mixer``.
+
+    The player preloads requested sound files and keeps them in memory for
+    near-zero latency playback. It uses dependency injection friendly
+    factories to aid unit testing.
+    """
+
+    def __init__(
+        self,
+        mixer: Optional[pygame.mixer] = None,
+        logger: Optional[Logger] = None,
+    ) -> None:
+        self._mixer = mixer or pygame.mixer
+        self._logger = logger or logging.getLogger(__name__)
+        self._sounds: Dict[str, pygame.mixer.Sound] = {}
+        self._initialized = False
+
+    def initialize(
+        self,
+        *,
+        frequency: int = 44_100,
+        size: int = -16,
+        channels: int = 2,
+        buffer: int = 512,
+    ) -> None:
+        """Initialize the mixer subsystem if it is not already running."""
+
+        if self._initialized:
+            return
+        self._mixer.init(
+            frequency=frequency,
+            size=size,
+            channels=channels,
+            buffer=buffer,
+        )
+        self._initialized = True
+        self._logger.info(
+            "Initialized audio mixer (freq=%s, size=%s, channels=%s, buffer=%s)",
+            frequency,
+            size,
+            channels,
+            buffer,
+        )
+
+    def shutdown(self) -> None:
+        """Stop playback and release all loaded sounds."""
+
+        if not self._initialized:
+            return
+        self.stop_all()
+        self._mixer.quit()
+        self._sounds.clear()
+        self._initialized = False
+        self._logger.info("Audio mixer shut down")
+
+    def load(self, sound_id: str, file_path: str) -> bool:
+        """Load an audio file and associate it with ``sound_id``.
+
+        Returns ``True`` when the file was loaded successfully, ``False``
+        otherwise. Errors are logged but never raised to the caller.
+        """
+
+        if not sound_id:
+            raise ValueError("sound_id must be provided")
+
+        path = Path(file_path)
+        if not path.is_file():
+            self._logger.warning("Sound file missing: %s", path)
+            return False
+
+        self._ensure_initialized()
+
+        try:
+            sound = self._mixer.Sound(path.as_posix())
+        except Exception:  # pragma: no cover - defensive logging
+            self._logger.exception("Failed to load sound: %s", path)
+            return False
+
+        self._sounds[sound_id] = sound
+        self._logger.info("Loaded sound '%s' from %s", sound_id, path)
+        return True
+
+    def unload(self, sound_id: str) -> bool:
+        """Remove a previously loaded sound from memory."""
+
+        removed = self._sounds.pop(sound_id, None)
+        if removed is None:
+            self._logger.debug("Attempted to unload missing sound '%s'", sound_id)
+            return False
+        self._logger.info("Unloaded sound '%s'", sound_id)
+        return True
+
+    def play(self, sound_id: str, *, loops: int = 0) -> bool:
+        """Play a loaded sound. Returns ``True`` if playback began."""
+
+        sound = self._sounds.get(sound_id)
+        if sound is None:
+            self._logger.warning("Sound '%s' not loaded", sound_id)
+            return False
+        try:
+            sound.play(loops=loops)
+        except Exception:  # pragma: no cover - defensive logging
+            self._logger.exception("Failed to play sound '%s'", sound_id)
+            return False
+        return True
+
+    def stop_all(self) -> None:
+        """Stop playback for all channels."""
+
+        if not self._initialized:
+            return
+        self._mixer.stop()
+
+    def loaded_sounds(self) -> Dict[str, pygame.mixer.Sound]:
+        """Return a shallow copy of the loaded sound mapping."""
+
+        return dict(self._sounds)
+
+    def _ensure_initialized(self) -> None:
+        if not self._initialized:
+            self.initialize()

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from stream_companion.sound import SoundPlayer
+
+
+class DummySound:
+    def __init__(self) -> None:
+        self.play_calls: list[Dict[str, int]] = []
+
+    def play(self, *, loops: int = 0) -> None:
+        self.play_calls.append({"loops": loops})
+
+
+class DummyMixer:
+    def __init__(self) -> None:
+        self.init_calls: list[Dict[str, int]] = []
+        self.quit_calls = 0
+        self.stop_calls = 0
+        self.sounds: Dict[Path, DummySound] = {}
+
+    def init(self, *, frequency: int, size: int, channels: int, buffer: int) -> None:
+        self.init_calls.append(
+            {
+                "frequency": frequency,
+                "size": size,
+                "channels": channels,
+                "buffer": buffer,
+            }
+        )
+
+    def quit(self) -> None:
+        self.quit_calls += 1
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+    def Sound(self, path: str) -> DummySound:  # noqa: N802 - mimicking pygame API
+        dummy = DummySound()
+        self.sounds[Path(path)] = dummy
+        return dummy
+
+
+@pytest.fixture()
+def temp_sound(tmp_path: Path) -> Path:
+    path = tmp_path / "sound.wav"
+    path.write_bytes(b"fake sound data")
+    return path
+
+
+@pytest.fixture()
+def player(temp_sound: Path) -> tuple[SoundPlayer, DummyMixer]:
+    mixer = DummyMixer()
+    instance = SoundPlayer(mixer=mixer, logger=logging.getLogger("test.sound"))
+    return instance, mixer
+
+
+def test_initialize_is_idempotent(player: tuple[SoundPlayer, DummyMixer]) -> None:
+    sound_player, mixer = player
+    sound_player.initialize()
+    sound_player.initialize()
+
+    assert len(mixer.init_calls) == 1
+
+
+def test_load_invalid_path_logs_warning(player: tuple[SoundPlayer, DummyMixer]) -> None:
+    sound_player, _ = player
+    assert sound_player.load("sfx", "missing.wav") is False
+
+
+def test_load_valid_path_registers_sound(
+    player: tuple[SoundPlayer, DummyMixer], temp_sound: Path
+) -> None:
+    sound_player, mixer = player
+    assert sound_player.load("sfx", temp_sound.as_posix()) is True
+    assert "sfx" in sound_player.loaded_sounds()
+    assert temp_sound in mixer.sounds
+
+
+def test_play_loaded_sound(
+    player: tuple[SoundPlayer, DummyMixer], temp_sound: Path
+) -> None:
+    sound_player, _ = player
+    sound_player.load("sfx", temp_sound.as_posix())
+    assert sound_player.play("sfx", loops=2) is True
+
+
+def test_play_missing_sound_returns_false(
+    player: tuple[SoundPlayer, DummyMixer],
+) -> None:
+    sound_player, _ = player
+    assert sound_player.play("missing") is False
+
+
+def test_unload_sound(player: tuple[SoundPlayer, DummyMixer], temp_sound: Path) -> None:
+    sound_player, _ = player
+    sound_player.load("sfx", temp_sound.as_posix())
+    assert sound_player.unload("sfx") is True
+    assert sound_player.unload("sfx") is False
+
+
+def test_shutdown_quits_mixer(
+    player: tuple[SoundPlayer, DummyMixer], temp_sound: Path
+) -> None:
+    sound_player, mixer = player
+    sound_player.load("sfx", temp_sound.as_posix())
+    sound_player.shutdown()
+
+    assert mixer.quit_calls == 1
+    assert mixer.stop_calls == 1
+    assert sound_player.loaded_sounds() == {}


### PR DESCRIPTION
## Summary
- add `SoundPlayer` module that wraps `pygame.mixer` with preload/play/unload/shutdown helpers
- expose the module in the package namespace
- add dedicated unit tests with dummy mixer/sound fakes to validate behaviour

## Testing
- `python run_checks.py`

Fixes #2