### PR TITLE
Add overlay window component with tests and demo

### DIFF
--- a/examples/overlay_demo.py
+++ b/examples/overlay_demo.py
@@ -1,0 +1,43 @@
+"""Manual demonstration script for the OverlayWindow component."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication
+
+from stream_companion.overlay import OverlayWindow
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("asset", type=Path, help="Path to a PNG or GIF asset")
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=1500,
+        help="Auto-hide duration in ms (0 to persist)",
+    )
+    parser.add_argument("--x", type=int, default=None, help="Overlay X position")
+    parser.add_argument("--y", type=int, default=None, help="Overlay Y position")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = OverlayWindow(auto_hide_ms=args.duration)
+    window.show_asset(
+        args.asset.as_posix(),
+        duration_ms=args.duration,
+        position=(
+            (args.x, args.y) if args.x is not None and args.y is not None else None
+        ),
+    )
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stream_companion/__init__.py
+++ b/src/stream_companion/__init__.py
@@ -1,3 +1,3 @@
 """Streaming Companion Tool core package."""
 
-__all__ = ["hotkeys", "sound"]
+__all__ = ["hotkeys", "sound", "overlay"]

--- a/src/stream_companion/overlay.py
+++ b/src/stream_companion/overlay.py
@@ -1,0 +1,167 @@
+"""Overlay window utilities for the Streaming Companion Tool.
+
+This module provides the `OverlayWindow` class for displaying PNG and GIF
+assets on-screen using PySide6. The window is borderless, transparent, and
+auto-hides after a configurable duration.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+from PySide6.QtCore import QPoint, Qt, QTimer
+from PySide6.QtGui import QMovie, QPixmap
+from PySide6.QtWidgets import QLabel, QWidget
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OverlayWindow(QWidget):
+    """Display PNG/GIF overlays in a frameless, transparent window.
+
+    The overlay window keeps a `QLabel` as its sole child. Static images are
+    rendered via `QPixmap`, while GIF animations are played through `QMovie`.
+    A single-shot `QTimer` hides the window after the configured duration.
+
+    Args:
+        auto_hide_ms: Default duration before the window auto-hides. Set to
+            ``0`` to keep the overlay visible until hidden manually.
+        parent: Optional parent widget.
+    """
+
+    def __init__(
+        self, *, auto_hide_ms: int = 1500, parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        self._auto_hide_ms = auto_hide_ms
+        self._timer = QTimer(self)
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self.hide)
+
+        self._label = QLabel(self)
+        self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self._movie: Optional[QMovie] = None
+
+        self._configure_window_flags()
+
+    def show_asset(
+        self,
+        asset_path: str,
+        *,
+        duration_ms: Optional[int] = None,
+        position: Optional[Tuple[int, int]] = None,
+    ) -> bool:
+        """Display an asset from disk.
+
+        Args:
+            asset_path: Absolute or relative path to the PNG/GIF file.
+            duration_ms: Optional override for the auto-hide timer. ``None``
+                uses the instance default. ``0`` disables auto-hiding.
+            position: Optional ``(x, y)`` coordinates for the overlay. When
+                omitted, the window is left at its current position.
+
+        Returns:
+            ``True`` when the asset was successfully displayed, otherwise
+            ``False``.
+        """
+
+        path = Path(asset_path)
+        if not path.exists() or not path.is_file():
+            _LOGGER.warning("Overlay asset missing or not a file: %s", path)
+            return False
+
+        is_gif = path.suffix.lower() == ".gif"
+        if is_gif:
+            if not self._prepare_movie(path):
+                return False
+        else:
+            if not self._prepare_pixmap(path):
+                return False
+
+        self._start_timer(duration_ms)
+
+        if position is not None:
+            self.move(QPoint(position[0], position[1]))
+
+        self.show()
+        self.raise_()
+        return True
+
+    def is_animating(self) -> bool:
+        """Return ``True`` when a GIF is currently playing."""
+
+        return bool(self._movie and self._movie.state() == QMovie.Running)
+
+    def is_auto_hide_active(self) -> bool:
+        """Return ``True`` when the auto-hide timer is active."""
+
+        return self._timer.isActive()
+
+    def hideEvent(self, event) -> None:  # type: ignore[override]
+        self._stop_animation()
+        self._label.clear()
+        super().hideEvent(event)
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        self._stop_animation()
+        super().closeEvent(event)
+
+    def _configure_window_flags(self) -> None:
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Tool
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
+
+    def _prepare_pixmap(self, path: Path) -> bool:
+        pixmap = QPixmap(path.as_posix())
+        if pixmap.isNull():
+            _LOGGER.warning("Overlay image failed to load: %s", path)
+            return False
+
+        self._stop_animation()
+        self._label.setPixmap(pixmap)
+        self._resize_to_pixmap(pixmap)
+        return True
+
+    def _prepare_movie(self, path: Path) -> bool:
+        movie = QMovie(path.as_posix())
+        if not movie.isValid():
+            _LOGGER.warning("Overlay animation invalid: %s", path)
+            return False
+
+        self._stop_animation()
+        movie.setCacheMode(QMovie.CacheMode.CacheAll)
+        movie.start()
+        if movie.currentPixmap().isNull():
+            movie.jumpToFrame(0)
+
+        self._label.setMovie(movie)
+        self._resize_to_pixmap(movie.currentPixmap())
+        self._movie = movie
+        return True
+
+    def _resize_to_pixmap(self, pixmap: QPixmap) -> None:
+        if pixmap.isNull():
+            return
+        size = pixmap.size()
+        self._label.resize(size)
+        self.resize(size)
+
+    def _start_timer(self, duration_ms: Optional[int]) -> None:
+        effective = self._auto_hide_ms if duration_ms is None else duration_ms
+        if effective and effective > 0:
+            self._timer.start(effective)
+        else:
+            self._timer.stop()
+
+    def _stop_animation(self) -> None:
+        if self._movie:
+            self._movie.stop()
+            self._label.setMovie(None)
+            self._movie = None

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPixmap
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication
+
+from stream_companion.overlay import OverlayWindow
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_offscreen_platform() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="session")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture()
+def overlay(qapp: QApplication) -> OverlayWindow:
+    window = OverlayWindow(auto_hide_ms=100)
+    yield window
+    window.close()
+
+
+@pytest.fixture()
+def png_asset(tmp_path: Path) -> Path:
+    path = tmp_path / "overlay.png"
+    pixmap = QPixmap(16, 16)
+    pixmap.fill(Qt.GlobalColor.red)
+    assert pixmap.save(str(path), "PNG")
+    return path
+
+
+@pytest.fixture()
+def gif_asset(tmp_path: Path) -> Path:
+    # Minimal 1x1 pixel GIF image
+    gif_bytes = (
+        b"GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\x00\x00\x00\x00\x00!\xf9\x04"
+        b"\x01\n\x00\x01\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+    )
+    path = tmp_path / "overlay.gif"
+    path.write_bytes(gif_bytes)
+    return path
+
+
+def test_show_static_image(overlay: OverlayWindow, png_asset: Path) -> None:
+    assert overlay.show_asset(png_asset.as_posix(), duration_ms=150) is True
+    assert overlay.isVisible() is True
+    assert overlay.is_auto_hide_active() is True
+
+    QTest.qWait(200)
+    assert overlay.isVisible() is False
+
+
+def test_show_gif_animation(overlay: OverlayWindow, gif_asset: Path) -> None:
+    assert overlay.show_asset(gif_asset.as_posix(), duration_ms=0) is True
+    assert overlay.is_animating() is True
+    assert overlay.is_auto_hide_active() is False
+
+    overlay.hide()
+    QTest.qWait(50)
+    assert overlay.is_animating() is False
+
+
+def test_missing_asset_returns_false(overlay: OverlayWindow) -> None:
+    assert overlay.show_asset("missing.png") is False
+    assert overlay.isVisible() is False


### PR DESCRIPTION
## Summary
- introduce `OverlayWindow` for transparent PNG/GIF overlays with configurable auto-hide timing
- add Qt-based unit tests validating static images, GIF animation lifecycle, and missing asset handling
- provide an `examples/overlay_demo.py` script for manual verification of overlay positioning and duration

## Testing
- `python run_checks.py`

Fixes #3