### PR TITLE
Wire MVP services into runnable application

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,55 @@
+"""Command-line entry point for the Streaming Companion Tool MVP."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent
+SRC_DIR = ROOT_DIR / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from stream_companion import application, registry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default: INFO)",
+    )
+    return parser.parse_args()
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def ensure_assets_exist() -> None:
+    for shortcut in registry.iter_shortcuts():
+        if shortcut.sound_path and not Path(shortcut.sound_path).is_file():
+            _LOGGER.warning("Sound asset missing: %s", shortcut.sound_path)
+        if shortcut.overlay and not Path(shortcut.overlay.file).is_file():
+            _LOGGER.warning("Overlay asset missing: %s", shortcut.overlay.file)
+
+
+def main() -> None:
+    args = parse_args()
+    configure_logging(args.log_level)
+
+    ensure_assets_exist()
+    application.run_application(registry.iter_shortcuts())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stream_companion/__init__.py
+++ b/src/stream_companion/__init__.py
@@ -1,3 +1,10 @@
 """Streaming Companion Tool core package."""
 
-__all__ = ["hotkeys", "sound", "overlay"]
+__all__ = [
+    "application",
+    "hotkeys",
+    "models",
+    "overlay",
+    "registry",
+    "sound",
+]

--- a/src/stream_companion/application.py
+++ b/src/stream_companion/application.py
@@ -1,0 +1,134 @@
+"""Application wiring for the Streaming Companion Tool MVP."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Optional
+
+from PySide6.QtWidgets import QApplication
+
+from .hotkeys import HotkeyManager
+from .models import OverlayConfig, Shortcut
+from .overlay import OverlayWindow
+from .sound import SoundPlayer
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Application:
+    """Coordinates the MVP services for hotkey-triggered overlays and audio."""
+
+    def __init__(
+        self,
+        shortcuts: Iterable[Shortcut],
+        *,
+        sound_player: Optional[SoundPlayer] = None,
+        overlay_window: Optional[OverlayWindow] = None,
+        hotkey_manager: Optional[HotkeyManager] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._shortcuts: List[Shortcut] = list(shortcuts)
+        self._sound_player = sound_player or SoundPlayer()
+        self._overlay_window = overlay_window or OverlayWindow()
+        self._hotkey_manager = hotkey_manager or HotkeyManager()
+        self._logger = logger or _LOGGER
+
+        self._sound_ids: Dict[Shortcut, str] = {}
+        self._registered = False
+
+    def start(self) -> None:
+        """Preload assets, register shortcuts, and start the listener."""
+
+        if self._registered:
+            return
+
+        self._preload_sounds()
+        self._register_hotkeys()
+
+        started = self._hotkey_manager.start()
+        if started:
+            self._registered = True
+            self._logger.info(
+                "Application started with %d shortcuts", len(self._shortcuts)
+            )
+
+    def stop(self) -> None:
+        """Stop listening and release audio resources."""
+
+        if not self._registered:
+            return
+        self._hotkey_manager.stop()
+        self._sound_player.shutdown()
+        self._registered = False
+        self._logger.info("Application stopped")
+
+    def _preload_sounds(self) -> None:
+        for shortcut in self._shortcuts:
+            path = shortcut.sound_path
+            if not path:
+                continue
+            sound_id = self._unique_sound_id(shortcut)
+            success = self._sound_player.load(sound_id, path)
+            if success:
+                self._sound_ids[shortcut] = sound_id
+            else:
+                self._logger.warning("Failed to preload sound for %s", shortcut.hotkey)
+
+    def _unique_sound_id(self, shortcut: Shortcut) -> str:
+        base = shortcut.sound_id() or f"sound_{len(self._sound_ids) + 1}"
+        candidate = base
+        counter = 1
+        existing = set(self._sound_ids.values())
+        while candidate in existing:
+            counter += 1
+            candidate = f"{base}_{counter}"
+        return candidate
+
+    def _register_hotkeys(self) -> None:
+        for shortcut in self._shortcuts:
+            try:
+                self._hotkey_manager.register_hotkey(
+                    shortcut.hotkey,
+                    lambda sc=shortcut: self._handle_shortcut(sc),
+                )
+            except ValueError as exc:
+                self._logger.warning(
+                    "Skipping duplicate or invalid hotkey '%s': %s",
+                    shortcut.hotkey,
+                    exc,
+                )
+
+    def _handle_shortcut(self, shortcut: Shortcut) -> None:
+        self._logger.info("Hotkey triggered: %s", shortcut.hotkey)
+        sound_id = self._sound_ids.get(shortcut)
+        if sound_id:
+            played = self._sound_player.play(sound_id)
+            if not played:
+                self._logger.warning("Unable to play sound for %s", shortcut.hotkey)
+        elif shortcut.sound_path:
+            self._logger.warning("Sound for %s was not preloaded", shortcut.hotkey)
+
+        if shortcut.overlay:
+            self._show_overlay(shortcut.overlay)
+
+    def _show_overlay(self, config: OverlayConfig) -> None:
+        success = self._overlay_window.show_asset(
+            config.file,
+            duration_ms=config.duration_ms,
+            position=(config.x, config.y),
+        )
+        if not success:
+            self._logger.warning("Overlay failed to display: %s", config.file)
+
+
+def run_application(shortcuts: Iterable[Shortcut]) -> None:
+    """Bootstrap the Qt application loop and start the MVP workflow."""
+
+    app = QApplication.instance() or QApplication([])
+    application = Application(shortcuts)
+    application.start()
+
+    try:
+        app.exec()
+    finally:
+        application.stop()

--- a/src/stream_companion/models.py
+++ b/src/stream_companion/models.py
@@ -1,0 +1,33 @@
+"""Core data models for the Streaming Companion Tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class OverlayConfig:
+    """Configuration describing an overlay asset and its placement."""
+
+    file: str
+    x: int = 0
+    y: int = 0
+    duration_ms: int = 1500
+
+
+@dataclass(frozen=True)
+class Shortcut:
+    """Representation of a triggerable shortcut."""
+
+    hotkey: str
+    sound_path: Optional[str] = None
+    overlay: Optional[OverlayConfig] = None
+
+    def sound_id(self) -> Optional[str]:
+        """Derive a reusable sound identifier from the configured path."""
+
+        if not self.sound_path:
+            return None
+        return Path(self.sound_path).stem

--- a/src/stream_companion/registry.py
+++ b/src/stream_companion/registry.py
@@ -1,0 +1,39 @@
+"""Shortcut registry for the Streaming Companion Tool MVP."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+from .models import OverlayConfig, Shortcut
+
+_ASSETS_DIR = Path(__file__).resolve().parents[2] / "assets"
+
+
+def default_shortcuts() -> List[Shortcut]:
+    """Return the built-in shortcut list used for the Phase 1 MVP.
+
+    The registry references asset paths relative to the repository ``assets/``
+    directory. If an asset is missing at runtime the individual services log a
+    warning but continue operating, allowing streamers to customise the files
+    without modifying code.
+    """
+
+    return [
+        Shortcut(
+            hotkey="<ctrl>+<alt>+1",
+            sound_path=str(_ASSETS_DIR / "sample.wav"),
+            overlay=OverlayConfig(
+                file=str(_ASSETS_DIR / "sample.gif"),
+                x=960,
+                y=540,
+                duration_ms=1500,
+            ),
+        )
+    ]
+
+
+def iter_shortcuts() -> Iterable[Shortcut]:
+    """Convenience iterator over the default shortcuts."""
+
+    yield from default_shortcuts()

--- a/src/stream_companion/registry.py
+++ b/src/stream_companion/registry.py
@@ -7,33 +7,28 @@ from typing import Iterable, List
 
 from .models import OverlayConfig, Shortcut
 
+
 _ASSETS_DIR = Path(__file__).resolve().parents[2] / "assets"
 
 
 def default_shortcuts() -> List[Shortcut]:
     """Return the built-in shortcut list used for the Phase 1 MVP.
 
-    The registry references asset paths relative to the repository ``assets/``
-    directory. If an asset is missing at runtime the individual services log a
-    warning but continue operating, allowing streamers to customise the files
-    without modifying code.
+    The default registry is intentionally empty so that streamers can supply
+    their own configuration without shipping placeholder assets. Future phases
+    will populate this list from a JSON configuration file.
     """
 
-    return [
-        Shortcut(
-            hotkey="<ctrl>+<alt>+1",
-            sound_path=str(_ASSETS_DIR / "sample.wav"),
-            overlay=OverlayConfig(
-                file=str(_ASSETS_DIR / "sample.gif"),
-                x=960,
-                y=540,
-                duration_ms=1500,
-            ),
-        )
-    ]
+    return []
 
 
 def iter_shortcuts() -> Iterable[Shortcut]:
     """Convenience iterator over the default shortcuts."""
 
     yield from default_shortcuts()
+
+
+def assets_dir() -> Path:
+    """Return the canonical location for user-provided assets."""
+
+    return _ASSETS_DIR

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+import pytest
+
+from stream_companion.application import Application
+from stream_companion.models import OverlayConfig, Shortcut
+
+
+class FakeSoundPlayer:
+    def __init__(self, succeed: bool = True) -> None:
+        self.succeed = succeed
+        self.loaded: Dict[str, str] = {}
+        self.played: List[str] = []
+        self.shutdown_called = False
+
+    def load(self, sound_id: str, path: str) -> bool:
+        if self.succeed:
+            self.loaded[sound_id] = path
+        return self.succeed
+
+    def play(
+        self, sound_id: str, *, loops: int = 0
+    ) -> bool:  # noqa: ARG002 - test double interface
+        self.played.append(sound_id)
+        return True
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+class FakeOverlayWindow:
+    def __init__(self, succeed: bool = True) -> None:
+        self.succeed = succeed
+        self.calls: List[OverlayConfig] = []
+
+    def show_asset(
+        self, file: str, *, duration_ms: int, position: Optional[tuple[int, int]]
+    ) -> bool:
+        self.calls.append(
+            OverlayConfig(
+                file=file,
+                x=position[0] if position else 0,
+                y=position[1] if position else 0,
+                duration_ms=duration_ms,
+            )
+        )
+        return self.succeed
+
+
+class FakeHotkeyManager:
+    def __init__(self) -> None:
+        self.callbacks: Dict[str, callable] = {}
+        self.started = False
+        self.stopped = False
+
+    def register_hotkey(self, combination: str, callback) -> None:
+        if combination in self.callbacks:
+            raise ValueError("duplicate")
+        self.callbacks[combination] = callback
+
+    def start(self) -> bool:
+        self.started = True
+        return True
+
+    def stop(self) -> bool:
+        self.stopped = True
+        return True
+
+
+@pytest.fixture()
+def shortcut() -> Shortcut:
+    return Shortcut(
+        hotkey="<ctrl>+<alt>+k",
+        sound_path="/tmp/sound.wav",
+        overlay=OverlayConfig(file="/tmp/overlay.png", x=10, y=20, duration_ms=500),
+    )
+
+
+def test_application_registers_and_triggers_shortcut(shortcut: Shortcut) -> None:
+    sound = FakeSoundPlayer()
+    overlay = FakeOverlayWindow()
+    hotkeys = FakeHotkeyManager()
+
+    app = Application(
+        [shortcut], sound_player=sound, overlay_window=overlay, hotkey_manager=hotkeys
+    )
+    app.start()
+
+    assert sound.loaded  # sound preloaded
+    assert hotkeys.started is True
+    assert shortcut.hotkey in hotkeys.callbacks
+
+    hotkeys.callbacks[shortcut.hotkey]()
+
+    assert sound.played == list(sound.loaded.keys())
+    assert len(overlay.calls) == 1
+    assert overlay.calls[0].file == shortcut.overlay.file  # type: ignore[union-attr]
+
+    app.stop()
+    assert sound.shutdown_called is True
+    assert hotkeys.stopped is True
+
+
+def test_application_handles_missing_sound_gracefully(
+    shortcut: Shortcut, caplog: pytest.LogCaptureFixture
+) -> None:
+    sound = FakeSoundPlayer(succeed=False)
+    overlay = FakeOverlayWindow()
+    hotkeys = FakeHotkeyManager()
+
+    app = Application(
+        [shortcut], sound_player=sound, overlay_window=overlay, hotkey_manager=hotkeys
+    )
+    with caplog.at_level(logging.WARNING):
+        app.start()
+
+    assert not sound.loaded  # load failed
+    hotkeys.callbacks[shortcut.hotkey]()
+
+    assert overlay.calls  # overlay still displayed
+    assert "Failed to preload sound" in caplog.text
+    assert "Unable to play sound" in caplog.text or "was not preloaded" in caplog.text
+
+    app.stop()


### PR DESCRIPTION
## Summary
- add dataclasses for shortcuts/overlay configuration and expose helpers
- implement an `Application` orchestrator that preloads sounds, registers hotkeys, and dispatches callbacks
- rebuild `main.py` to launch the MVP workflow and introduce a default shortcut registry scaffold
- cover orchestration logic with unit tests using fakes for sound, overlay, and hotkey services

## Testing
- `python run_checks.py`

Fixes #4