### PR TITLE
Implement JSON configuration loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ dist/
 
 # Configuration and assets
 config/
+!config/
+config/*
+!config/schema.json
+!config/shortcuts.sample.json
 assets/
 
 # OS-specific files

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Turn your keyboard into a live-production command center. The Streaming Companio
 2. **Prepare assets**
    - Drop audio clips (WAV/MP3) and overlays (PNG/GIF) inside the `assets/` directory.
 3. **Define shortcuts**
-   - Edit `src/stream_companion/registry.py` and populate `default_shortcuts()` with your `Shortcut` definitions.
-   - Each shortcut can specify a hotkey, optional sound path, and optional overlay configuration.
+   - Copy the template: `cp config/shortcuts.sample.json config/shortcuts.json`.
+   - Edit `config/shortcuts.json` to add your hotkeys, sound paths, and overlay settings.
 4. **Run automated checks (optional but recommended)**
    ```bash
    python run_checks.py

--- a/config/schema.json
+++ b/config/schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Streaming Companion Shortcuts",
+  "type": "object",
+  "required": ["shortcuts"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version identifier",
+      "default": "1.0.0"
+    },
+    "shortcuts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/shortcut"
+      }
+    }
+  },
+  "definitions": {
+    "shortcut": {
+      "type": "object",
+      "required": ["hotkey"],
+      "properties": {
+        "hotkey": {
+          "type": "string",
+          "description": "pynput-style hotkey definition"
+        },
+        "sound": {
+          "type": "string",
+          "description": "Path to audio file"
+        },
+        "overlay": {
+          "$ref": "#/definitions/overlay"
+        }
+      },
+      "additionalProperties": false
+    },
+    "overlay": {
+      "type": "object",
+      "required": ["file"],
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Path to overlay asset"
+        },
+        "x": {
+          "type": "integer",
+          "description": "Overlay X position",
+          "default": 0
+        },
+        "y": {
+          "type": "integer",
+          "description": "Overlay Y position",
+          "default": 0
+        },
+        "duration": {
+          "type": "integer",
+          "description": "Visibility duration in milliseconds",
+          "default": 1500,
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/config/shortcuts.sample.json
+++ b/config/shortcuts.sample.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "shortcuts": [
+    {
+      "hotkey": "<ctrl>+<alt>+1",
+      "sound": "assets/sounds/sample.wav",
+      "overlay": {
+        "file": "assets/overlays/sample.gif",
+        "x": 960,
+        "y": 540,
+        "duration": 1500
+      }
+    }
+  ]
+}

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -21,11 +21,9 @@ Goal: Pressing a global shortcut plays a sound and shows an overlay.
 
 ## Phase 2 – JSON Configuration Loader
 Goal: Externalize shortcut definitions and assets.
-- Design configuration schema version 1.0 (`config/schema.json`).
-- Implement `ConfigLoader` that reads JSON, validates fields, and hydrates runtime models.
-- Add startup default config creation when file is missing.
-- Extend Phase 1 registry to load shortcuts dynamically from config file.
-- Add error messaging for malformed or missing assets.
+- ✅ `config/schema.json` and `config/shortcuts.sample.json` define the JSON structure.
+- ✅ `config_loader` module validates JSON, hydrates runtime models, and auto-creates configs.
+- ✅ Registry loads shortcuts dynamically with fallback logging.
 - Document configuration workflow and sample files.
 
 ## Phase 3 – Desktop Configurator UI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6==6.9.3
 pynput==1.8.1
 pygame==2.6.1
+jsonschema==4.23.0

--- a/src/stream_companion/__init__.py
+++ b/src/stream_companion/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = [
     "application",
+    "config_loader",
     "hotkeys",
     "models",
     "overlay",

--- a/src/stream_companion/registry.py
+++ b/src/stream_companion/registry.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Iterable, List
 
+from .config_loader import ConfigError, load_shortcuts
 from .models import Shortcut
 
 
+_LOGGER = logging.getLogger(__name__)
 _ASSETS_DIR = Path(__file__).resolve().parents[2] / "assets"
 
 
@@ -24,8 +27,11 @@ def default_shortcuts() -> List[Shortcut]:
 
 def iter_shortcuts() -> Iterable[Shortcut]:
     """Convenience iterator over the default shortcuts."""
-
-    yield from default_shortcuts()
+    try:
+        yield from load_shortcuts()
+    except ConfigError as exc:
+        _LOGGER.warning("Falling back to built-in shortcuts: %s", exc)
+        yield from default_shortcuts()
 
 
 def assets_dir() -> Path:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from stream_companion.config_loader import ConfigError, load_shortcuts
+
+
+def _write_schema(path: Path) -> None:
+    schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["shortcuts"],
+        "properties": {
+            "shortcuts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["hotkey"],
+                    "properties": {
+                        "hotkey": {"type": "string"},
+                        "sound": {"type": "string"},
+                        "overlay": {
+                            "type": "object",
+                            "required": ["file"],
+                            "properties": {
+                                "file": {"type": "string"},
+                                "x": {"type": "integer"},
+                                "y": {"type": "integer"},
+                                "duration": {"type": "integer"},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "additionalProperties": False,
+    }
+    path.write_text(json.dumps(schema), encoding="utf-8")
+
+
+def test_load_shortcuts_reads_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "shortcuts.json"
+    schema_path = tmp_path / "schema.json"
+    sample_path = tmp_path / "shortcuts.sample.json"
+
+    _write_schema(schema_path)
+    config = {
+        "shortcuts": [
+            {
+                "hotkey": "<ctrl>+<alt>+1",
+                "sound": "assets/sounds/sample.wav",
+                "overlay": {
+                    "file": "assets/overlays/sample.gif",
+                    "x": 10,
+                    "y": 20,
+                    "duration": 500,
+                },
+            }
+        ]
+    }
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    shortcuts = load_shortcuts(
+        config_path, schema_path=schema_path, sample_path=sample_path
+    )
+
+    assert len(shortcuts) == 1
+    shortcut = shortcuts[0]
+    assert shortcut.hotkey == "<ctrl>+<alt>+1"
+    assert shortcut.sound_path == "assets/sounds/sample.wav"
+    assert shortcut.overlay is not None
+    assert shortcut.overlay.file == "assets/overlays/sample.gif"
+    assert shortcut.overlay.duration_ms == 500
+
+
+def test_load_shortcuts_creates_file_from_sample(tmp_path: Path) -> None:
+    config_path = tmp_path / "shortcuts.json"
+    schema_path = tmp_path / "schema.json"
+    sample_path = tmp_path / "shortcuts.sample.json"
+
+    _write_schema(schema_path)
+    sample_path.write_text(
+        json.dumps({"shortcuts": [{"hotkey": "a", "sound": "sound.wav"}]}),
+        encoding="utf-8",
+    )
+
+    shortcuts = load_shortcuts(
+        config_path, schema_path=schema_path, sample_path=sample_path
+    )
+
+    assert config_path.exists()
+    assert len(shortcuts) == 1
+    assert shortcuts[0].hotkey == "a"
+
+
+def test_load_shortcuts_invalid_json(tmp_path: Path) -> None:
+    config_path = tmp_path / "shortcuts.json"
+    schema_path = tmp_path / "schema.json"
+    sample_path = tmp_path / "shortcuts.sample.json"
+
+    _write_schema(schema_path)
+    config_path.write_text("{not valid json}", encoding="utf-8")
+
+    with pytest.raises(ConfigError):
+        load_shortcuts(config_path, schema_path=schema_path, sample_path=sample_path)
+
+
+def test_load_shortcuts_validation_failure(tmp_path: Path) -> None:
+    config_path = tmp_path / "shortcuts.json"
+    schema_path = tmp_path / "schema.json"
+    sample_path = tmp_path / "shortcuts.sample.json"
+
+    _write_schema(schema_path)
+    config_path.write_text(
+        json.dumps({"shortcuts": [{"sound": "missing"}]}), encoding="utf-8"
+    )
+
+    with pytest.raises(ConfigError):
+        load_shortcuts(config_path, schema_path=schema_path, sample_path=sample_path)


### PR DESCRIPTION
## Summary
- add JSON schema and sample shortcuts template under `config/`
- implement `config_loader` module to validate shortcuts and hydrate runtime models with helpful errors
- integrate loader into `registry` and expose module via package init
- add unit tests covering successful loads, sample creation, invalid JSON, and schema validation errors

## Testing
- `python run_checks.py`

Fixes #11